### PR TITLE
Remove logic for checking secureHardware on device

### DIFF
--- a/app/src/androidTest/java/de/adorsys/android/securestoragetest/SecureStorage2BaseTest.kt
+++ b/app/src/androidTest/java/de/adorsys/android/securestoragetest/SecureStorage2BaseTest.kt
@@ -13,7 +13,7 @@ open class SecureStorage2BaseTest {
     @Rule
     @JvmField
     var activityRule = ActivityTestRule(
-        MainActivity::class.java
+            MainActivity::class.java
     )
 
     @Before
@@ -21,10 +21,9 @@ open class SecureStorage2BaseTest {
     fun setUp() {
         // Init library parameters
         SecureStorage.init(
-            context = activityRule.activity.applicationContext,
-            encryptionKeyAlias = "SecureStorage2Key",
-            x500Principal = "CN=SecureStorage2 , O=Adorsys GmbH & Co. KG., C=Germany",
-            useOnlyWithHardwareSupport = false
+                context = activityRule.activity.applicationContext,
+                encryptionKeyAlias = "SecureStorage2Key",
+                x500Principal = "CN=SecureStorage2 , O=Adorsys GmbH & Co. KG., C=Germany"
         )
 
         activityRule.activity.runOnUiThread {
@@ -34,11 +33,11 @@ open class SecureStorage2BaseTest {
 
             //turn the screen on
             activityRule.activity.window.addFlags(
-                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
-                        or WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD
-                        or WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-                        or WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
-                        or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+                            or WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD
+                            or WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+                            or WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                            or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
             )
         }
     }

--- a/app/src/main/java/de/adorsys/android/securestoragetest/App.kt
+++ b/app/src/main/java/de/adorsys/android/securestoragetest/App.kt
@@ -19,8 +19,7 @@ class App : Application() {
         SecureStorage.init(
                 context = applicationContext,
                 encryptionKeyAlias = "SecureStorage2Key",
-                x500Principal = "CN=SecureStorage2 , O=Adorsys GmbH & Co. KG., C=Germany",
-                useOnlyWithHardwareSupport = false
+                x500Principal = "CN=SecureStorage2 , O=Adorsys GmbH & Co. KG., C=Germany"
         )
 
         // In Espresso tests we initialize the SecureStorageKeys in the test class

--- a/securestoragelibrary/src/main/AndroidManifest.xml
+++ b/securestoragelibrary/src/main/AndroidManifest.xml
@@ -1,6 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="de.adorsys.android.securestoragelibrary">
-    <!--suppress DeprecatedClassUsageInspection -->
-    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-    <uses-permission android:name=" android.permission.USE_BIOMETRIC" />
-</manifest>
+<manifest package="de.adorsys.android.securestoragelibrary" />

--- a/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/internal/KeyStoreToolApi23.kt
+++ b/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/internal/KeyStoreToolApi23.kt
@@ -17,23 +17,24 @@
 package de.adorsys.android.securestoragelibrary.internal
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
-import java.security.KeyStore
-import java.security.KeyStoreException
-import android.security.keystore.KeyProperties
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyInfo
-import androidx.annotation.RequiresApi
+import android.security.keystore.KeyProperties
 import android.util.Base64
+import androidx.annotation.RequiresApi
 import de.adorsys.android.securestoragelibrary.SecureStorage
 import de.adorsys.android.securestoragelibrary.SecureStorageException
+import java.security.KeyStore
+import java.security.KeyStoreException
 import java.security.spec.InvalidKeySpecException
-import java.util.GregorianCalendar
+import java.util.*
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
-import javax.crypto.spec.IvParameterSpec
 import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.IvParameterSpec
 
 internal object KeyStoreToolApi23 {
 
@@ -52,99 +53,66 @@ internal object KeyStoreToolApi23 {
             return keyStoreInstance.getKey(SecureStorage.ENCRYPTION_KEY_ALIAS, null) != null
         } catch (e: Exception) {
             throw SecureStorageException(
-                if (!e.message.isNullOrBlank()) e.message!!
-                else SecureStorageException.MESSAGE_ERROR_WHILE_RETRIEVING_KEY,
-                e,
-                SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
+                    if (!e.message.isNullOrBlank()) e.message!!
+                    else SecureStorageException.MESSAGE_ERROR_WHILE_RETRIEVING_KEY,
+                    e,
+                    SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
             )
         }
     }
 
     @RequiresApi(Build.VERSION_CODES.M)
-    fun generateKey() {
+    fun generateKey(context: Context) {
         val keyGenerator = getKeyGenerator()
 
         val keyStartDate = GregorianCalendar.getInstance()
         keyStartDate.add(GregorianCalendar.DAY_OF_MONTH, -1)
 
         val keyGenParameterSpecBuilder =
-            when {
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> KeyGenParameterSpec.Builder(
-                    SecureStorage.ENCRYPTION_KEY_ALIAS,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-                )
-                    .setKeyValidityStart(keyStartDate.time)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-                    .setKeySize(AES_KEY_BIT_SIZE)
-                    .setIsStrongBoxBacked(SecureStorage.EXPLICITLY_USE_SECURE_HARDWARE)
-                else -> KeyGenParameterSpec.Builder(
-                    SecureStorage.ENCRYPTION_KEY_ALIAS,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-                )
-                    .setKeyValidityStart(keyStartDate.time)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-                    .setKeySize(AES_KEY_BIT_SIZE)
-            }
+                when {
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> KeyGenParameterSpec.Builder(
+                            SecureStorage.ENCRYPTION_KEY_ALIAS,
+                            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                    )
+                            .setKeyValidityStart(keyStartDate.time)
+                            .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                            .setKeySize(AES_KEY_BIT_SIZE)
+                            .setIsStrongBoxBacked(hasStrongBox(context))
+                    else -> KeyGenParameterSpec.Builder(
+                            SecureStorage.ENCRYPTION_KEY_ALIAS,
+                            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                    )
+                            .setKeyValidityStart(keyStartDate.time)
+                            .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                            .setKeySize(AES_KEY_BIT_SIZE)
+                }
 
         keyGenerator.init(keyGenParameterSpecBuilder.build())
         keyGenerator.generateKey()
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
-    internal fun deviceHasSecureHardwareSupport(): Boolean {
-        val keyGenerator = getKeyGenerator()
-
-        val keyStartDate = GregorianCalendar.getInstance()
-        keyStartDate.add(GregorianCalendar.DAY_OF_MONTH, -1)
-
-        val keyGenParameterSpecBuilder =
-            when {
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> KeyGenParameterSpec.Builder(
-                    KeyStoreTool.KEY_SECURE_HARDWARE_ALIAS,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-                )
-                    .setKeyValidityStart(keyStartDate.time)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-                    .setKeySize(AES_KEY_BIT_SIZE)
-                    .setIsStrongBoxBacked(SecureStorage.EXPLICITLY_USE_SECURE_HARDWARE)
-                else -> KeyGenParameterSpec.Builder(
-                    KeyStoreTool.KEY_SECURE_HARDWARE_ALIAS,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-                )
-                    .setKeyValidityStart(keyStartDate.time)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-                    .setKeySize(AES_KEY_BIT_SIZE)
-            }
-
-        keyGenerator.init(keyGenParameterSpecBuilder.build())
-        val secretKey = keyGenerator.generateKey()
-
-        return getKeyInfo(secretKey)?.isInsideSecureHardware ?: false
+    @RequiresApi(Build.VERSION_CODES.P)
+    private fun hasStrongBox(context: Context): Boolean {
+        return context.packageManager.hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE)
     }
 
     @RequiresApi(Build.VERSION_CODES.M)
-    internal fun isKeyInsideSecureHardware(keyStoreInstance: KeyStore): Boolean =
-        getKeyInfo(getSecretKey(keyStoreInstance))?.isInsideSecureHardware ?: false
-
-    @RequiresApi(Build.VERSION_CODES.M)
     internal fun encryptValue(
-        context: Context,
-        keyStoreInstance: KeyStore,
-        cipher: Cipher,
-        key: String,
-        value: String
+            context: Context,
+            keyStoreInstance: KeyStore,
+            cipher: Cipher,
+            key: String,
+            value: String
     ): String {
 
         val secretKey = when {
             keyExists(keyStoreInstance) -> getSecretKey(keyStoreInstance)
             else -> throw SecureStorageException(
-                SecureStorageException.MESSAGE_KEY_DOES_NOT_EXIST,
-                null,
-                SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
+                    SecureStorageException.MESSAGE_KEY_DOES_NOT_EXIST,
+                    null,
+                    SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
             )
         }
 
@@ -156,22 +124,22 @@ internal object KeyStoreToolApi23 {
 
     @RequiresApi(Build.VERSION_CODES.M)
     internal fun decryptValue(
-        context: Context,
-        keyStoreInstance: KeyStore,
-        cipher: Cipher,
-        key: String,
-        value: String
+            context: Context,
+            keyStoreInstance: KeyStore,
+            cipher: Cipher,
+            key: String,
+            value: String
     ): String {
 
         val secretKey = getSecretKey(keyStoreInstance) ?: throw SecureStorageException(
-            SecureStorageException.MESSAGE_KEY_DOES_NOT_EXIST,
-            null,
-            SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
+                SecureStorageException.MESSAGE_KEY_DOES_NOT_EXIST,
+                null,
+                SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
         )
 
         cipher.init(
-            Cipher.DECRYPT_MODE, secretKey,
-            IvParameterSpec(getIVFromSecureStorage(context, key))
+                Cipher.DECRYPT_MODE, secretKey,
+                IvParameterSpec(getIVFromSecureStorage(context, key))
         )
         val encryptedData = Base64.decode(value, Base64.DEFAULT)
         val decodedData = cipher.doFinal(encryptedData)
@@ -186,16 +154,16 @@ internal object KeyStoreToolApi23 {
                 keyStoreInstance.deleteEntry(SecureStorage.ENCRYPTION_KEY_ALIAS)
             } catch (e: KeyStoreException) {
                 throw SecureStorageException(
-                    if (!e.message.isNullOrBlank()) e.message!!
-                    else SecureStorageException.MESSAGE_ERROR_WHILE_DELETING_KEY,
-                    e,
-                    SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
+                        if (!e.message.isNullOrBlank()) e.message!!
+                        else SecureStorageException.MESSAGE_ERROR_WHILE_DELETING_KEY,
+                        e,
+                        SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
                 )
             }
             else -> throw SecureStorageException(
-                SecureStorageException.MESSAGE_KEY_DOES_NOT_EXIST,
-                null,
-                SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
+                    SecureStorageException.MESSAGE_KEY_DOES_NOT_EXIST,
+                    null,
+                    SecureStorageException.ExceptionType.KEYSTORE_EXCEPTION
             )
         }
     }
@@ -203,7 +171,7 @@ internal object KeyStoreToolApi23 {
     @RequiresApi(Build.VERSION_CODES.M)
     private fun saveIVInSecureStorage(context: Context, key: String, iv: ByteArray) {
         val preferences =
-            context.getSharedPreferences(SecureStorage.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+                context.getSharedPreferences(SecureStorage.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
         val encodedIv = Base64.encodeToString(iv, Base64.DEFAULT)
         preferences.edit().putString("$KEY_CIPHER_IV$key", encodedIv).apply()
     }
@@ -211,18 +179,18 @@ internal object KeyStoreToolApi23 {
     @RequiresApi(Build.VERSION_CODES.M)
     private fun getIVFromSecureStorage(context: Context, key: String): ByteArray {
         val preferences =
-            context.getSharedPreferences(SecureStorage.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
+                context.getSharedPreferences(SecureStorage.SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE)
         val encodedIv = preferences.getString("$KEY_CIPHER_IV$key", null)
         return Base64.decode(encodedIv, Base64.DEFAULT)
     }
 
     @RequiresApi(Build.VERSION_CODES.M)
     private fun getKeyGenerator(): KeyGenerator = KeyGenerator
-        .getInstance(KeyProperties.KEY_ALGORITHM_AES, KEY_GENERATOR_PROVIDER)
+            .getInstance(KeyProperties.KEY_ALGORITHM_AES, KEY_GENERATOR_PROVIDER)
 
     @RequiresApi(Build.VERSION_CODES.M)
     private fun getSecretKey(keyStoreInstance: KeyStore): SecretKey? = (keyStoreInstance
-        .getEntry(SecureStorage.ENCRYPTION_KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey
+            .getEntry(SecureStorage.ENCRYPTION_KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey
 
     @RequiresApi(Build.VERSION_CODES.M)
     private fun getKeyInfo(secretKey: SecretKey?): KeyInfo? {

--- a/securestoragelibrary/src/main/res/values/strings.xml
+++ b/securestoragelibrary/src/main/res/values/strings.xml
@@ -1,3 +1,1 @@
-<resources>
-
-</resources>
+<resources />


### PR DESCRIPTION
Pre API23 secureHardware cannot be checked without the possibility of running into errors so the logic is removed fully from the library to avoid discrepancies.