### PR TITLE
Add support for ordered collections of strings.

### DIFF
--- a/app/src/androidTest/java/de/adorsys/android/securestoragetest/SecureStorageLogicTest.kt
+++ b/app/src/androidTest/java/de/adorsys/android/securestoragetest/SecureStorageLogicTest.kt
@@ -52,6 +52,76 @@ open class SecureStorageLogicTest : SecureStorageBaseTest() {
     }
 
     @Test
+    fun testStoreRetrieveAndRemoveStringSetValue() {
+        val KEY_STRING_SET = "KEY_STRING_SET"
+        val VALUE_STRING_SET = setOf(
+            "The wheels on the \uD83D\uDE8C go, Round and round, Round and round, Round and round.",
+            "The wheels on the \uD83D\uDE8C go Round and round, All through the town. The doors on",
+            "the \uD83D\uDE8C go, Open and shut ♫, Open and shut ♫, Open and shut."
+        )
+        val context = activityRule.activity.applicationContext
+
+        // Store a String Set value in SecureStorage
+        SecurePreferences.setValue(context, KEY_STRING_SET, VALUE_STRING_SET)
+
+        // Check if the value exists in SecureStorage
+        Assert.assertTrue(SecurePreferences.contains(context, KEY_STRING_SET))
+
+        // Retrieve the previously stored String Set value from the SecureStorage
+        val retrievedValue: MutableSet<String> = SecurePreferences.getStringSetValue(context, KEY_STRING_SET, setOf())
+
+        // Check if the retrievedValue is not null
+        Assert.assertEquals(VALUE_STRING_SET.size, retrievedValue.size)
+
+        // Check if the retrievedValue equals the pre-stored value
+        Assert.assertEquals(VALUE_STRING_SET, retrievedValue)
+
+        // Remove the String Set value from SecureStorage
+        SecurePreferences.removeValue(context, KEY_STRING_SET)
+
+        // Check if the String Set value has been removed from SecureStorage
+        Assert.assertFalse(SecurePreferences.contains(context, KEY_STRING_SET))
+
+        // Delete keys and clear SecureStorage
+        SecurePreferences.clearAllValues(context)
+    }
+
+    @Test
+    fun testStoreRetrieveAndRemoveStringListValue() {
+        val KEY_STRING_LIST = "KEY_STRING_LIST"
+        val VALUE_STRING_LIST = listOf(
+            "The wheels on the \uD83D\uDE8C go, Round and round, Round and round, Round and round.",
+            "The wheels on the \uD83D\uDE8C go Round and round, All through the town. The doors on",
+            "the \uD83D\uDE8C go, Open and shut ♫, Open and shut ♫, Open and shut."
+        )
+        val context = activityRule.activity.applicationContext
+
+        // Store a String Set value in SecureStorage
+        SecurePreferences.setValue(context, KEY_STRING_LIST, VALUE_STRING_LIST)
+
+        // Check if the value exists in SecureStorage
+        Assert.assertTrue(SecurePreferences.contains(context, KEY_STRING_LIST))
+
+        // Retrieve the previously stored String Set value from the SecureStorage
+        val retrievedValue = SecurePreferences.getStringListValue(context, KEY_STRING_LIST, listOf())
+
+        // Check if the retrievedValue is not null
+        Assert.assertEquals(VALUE_STRING_LIST.size, retrievedValue.size)
+
+        // Check if the retrievedValue equals the pre-stored value
+        Assert.assertEquals(VALUE_STRING_LIST, retrievedValue)
+
+        // Remove the String Set value from SecureStorage
+        SecurePreferences.removeValue(context, KEY_STRING_LIST)
+
+        // Check if the String Set value has been removed from SecureStorage
+        Assert.assertFalse(SecurePreferences.contains(context, KEY_STRING_LIST))
+
+        // Delete keys and clear SecureStorage
+        SecurePreferences.clearAllValues(context)
+    }
+
+    @Test
     fun testStoreRetrieveAndRemoveBooleanValue() {
         val KEY_BOOLEAN = "KEY_BOOLEAN"
         val VALUE_BOOLEAN = true

--- a/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/SecurePreferences.java
+++ b/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/SecurePreferences.java
@@ -65,7 +65,7 @@ public final class SecurePreferences {
     }
 
     /**
-     * Takes plain string value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
+     * Takes plain boolean value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
      *
      * @param context Context is used internally
      * @param key     Key used to identify the stored value in SecureStorage
@@ -78,7 +78,7 @@ public final class SecurePreferences {
     }
 
     /**
-     * Takes plain string value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
+     * Takes plain float value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
      *
      * @param context Context is used internally
      * @param key     Key used to identify the stored value in SecureStorage
@@ -91,7 +91,7 @@ public final class SecurePreferences {
     }
 
     /**
-     * Takes plain string value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
+     * Takes plain long value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
      *
      * @param context Context is used internally
      * @param key     Key used to identify the stored value in SecureStorage
@@ -104,7 +104,7 @@ public final class SecurePreferences {
     }
 
     /**
-     * Takes plain string value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
+     * Takes plain int value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
      *
      * @param context Context is used internally
      * @param key     Key used to identify the stored value in SecureStorage
@@ -117,11 +117,11 @@ public final class SecurePreferences {
     }
 
     /**
-     * Takes plain string value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
+     * Takes plain Set&lt;String&gt; value, encrypts it and stores it encrypted in the SecureStorage on the Android Device
      *
      * @param context Context is used internally
      * @param key     Key used to identify the stored value in SecureStorage
-     * @param value   Plain Set(type: String) value that will be encrypted and stored in the SecureStorage
+     * @param value   Plain Set&lt;String&gt; value that will be encrypted and stored in the SecureStorage
      */
     public static void setValue(@NonNull Context context,
                                 @NonNull String key,

--- a/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/SecurePreferences.java
+++ b/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/SecurePreferences.java
@@ -271,6 +271,7 @@ public final class SecurePreferences {
                                    @NonNull String key) {
         Context applicationContext = context.getApplicationContext();
         removeSecureValue(applicationContext, key);
+        removeSecureCollectionValue(applicationContext, key);
     }
 
     /**
@@ -338,6 +339,17 @@ public final class SecurePreferences {
         preferences.edit().remove(key).apply();
     }
 
+    private static void removeSecureCollectionValue(@NonNull Context context,
+                                          @NonNull String key) {
+        int size = getIntValue(context, key + KEY_SET_COUNT_POSTFIX, -1);
+
+        if (size != -1) {
+            for (int i = 0; i < size; i++) {
+                removeSecureValue(context, key + "_" + i);
+            }
+            removeSecureValue(context,key + KEY_SET_COUNT_POSTFIX);
+        }
+    }
 
     /**
      * Checks if SecureStorage contains a String Set value for the given key. Since sets are stored

--- a/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/SecurePreferences.java
+++ b/securestoragelibrary/src/main/java/de/adorsys/android/securestoragelibrary/SecurePreferences.java
@@ -254,7 +254,8 @@ public final class SecurePreferences {
         SharedPreferences preferences = applicationContext
                 .getSharedPreferences(KEY_SHARED_PREFERENCES_NAME, MODE_PRIVATE);
         try {
-            return preferences.contains(key) && KeystoreTool.keyPairExists();
+            return (preferences.contains(key) || containsCollection(context, key))
+                    && KeystoreTool.keyPairExists();
         } catch (SecureStorageException e) {
             return false;
         }
@@ -335,6 +336,34 @@ public final class SecurePreferences {
         SharedPreferences preferences = context
                 .getSharedPreferences(KEY_SHARED_PREFERENCES_NAME, MODE_PRIVATE);
         preferences.edit().remove(key).apply();
+    }
+
+
+    /**
+     * Checks if SecureStorage contains a String Set value for the given key. Since sets are stored
+     * under multiple keys, this verifies that each expected key is present but does not verify the
+     * value types of those keys.
+     *
+     * @param context Context is used internally
+     * @param key     Key used to identify the stored value in SecureStorage
+     * @return True if the keys for the set value exist in SecureStorage, otherwise false
+     */
+    private static boolean containsCollection(@NonNull Context context,
+                                              @NonNull String key) {
+        Context applicationContext = context.getApplicationContext();
+        SharedPreferences preferences = applicationContext
+                .getSharedPreferences(KEY_SHARED_PREFERENCES_NAME, MODE_PRIVATE);
+
+        int size = getIntValue(context, key + KEY_SET_COUNT_POSTFIX, -1);
+
+        if (size == -1) {
+            return false;
+        }
+
+        for (int i = 0; i < size; i++) {
+            if (!preferences.contains(key + "_" + i)) return false;
+        }
+        return true;
     }
 
     private static void clearAllSecureValues(@NonNull Context context) {


### PR DESCRIPTION
While using this library with ordered sets, I encountered a critical bug that would silently permute values because sets would be saved _in order_ but loaded _in random order_! This was particularly bad for storing large keys, broken down into chunks. When restored, the values would change!! What made it so bad is that it would often work because sometimes the random order would match the initial order. So it got through several layers of testing, unnoticed.

This PR addresses the root issue by adding support for storing lists. Since Lists are inherently ordered, they are a more attractive option for developers who are breaking down large strings for storage. Also, the `getStringSetValue` function has been modified to use a LinkedHashSet under the hood, which is a non-breaking change but also makes it compatible with ordered sets.

Along the way, I encountered other bugs that I documented as github issues and fixed, as well. Lastly, I added unit tests in the style of existing tests to verify all new functionality.

All tests pass.